### PR TITLE
Poll to watch for files changing

### DIFF
--- a/dp-ui/bin/deploy
+++ b/dp-ui/bin/deploy
@@ -56,7 +56,7 @@ async function build() {
   await run(buildLibCmd)
 
   const buildNonParentCmd =
-    'lerna run --parallel build --scope ' +
+    'lerna run build --scope ' +
     `'{${allPackages
       .filter(e => e !== 'parent' && e !== 'lib')
       .map(e => '@dp-ui/' + e)

--- a/dp-ui/packages/parent/config/webpackDevServer.config.js
+++ b/dp-ui/packages/parent/config/webpackDevServer.config.js
@@ -110,6 +110,7 @@ module.exports = function(proxy, allowedHost) {
     // https://github.com/facebook/create-react-app/issues/1065
     watchOptions: {
       ignored: ignoredFiles(paths.appSrc),
+      poll: 1000,
     },
     https: getHttpsConfig(),
     host,

--- a/dp-ui/packages/treemap/package.json
+++ b/dp-ui/packages/treemap/package.json
@@ -10,7 +10,7 @@
   "main": "./dist/index.js",
   "types": "./dist/types.d.ts",
   "scripts": {
-    "build": "rimraf dist/ && tsc; cp -r src/assets dist/assets",
+    "build": "rimraf dist/ && tsc && cp -r src/assets dist/assets",
     "develop": "nodemon -x \"yarn run build\"",
     "lint": "eslint 'src/**/*.{js,jsx,ts,tsx}' --quiet --fix && prettier --write 'src/**/*.{js,jsx,ts,tsx}'",
     "test": "jest --no-cache",

--- a/dp-ui/packages/treemap/src/actions.ts
+++ b/dp-ui/packages/treemap/src/actions.ts
@@ -151,6 +151,8 @@ export const fetchAndSetTableMetadata =
 export const fetchAndSetColumnMetadata =
   (selectedDataset: string, selectedTable: string) =>
   (dispatch): Promise<CommonMetadata[]> => {
+    console.log('test')
+    console.log('test')
     const dataset = (selectedDataset || '').trim()
     const table = (selectedTable || '').trim()
     if (isEmpty(dataset)) {


### PR DESCRIPTION
In WSL live reloading in webpack doesn't work. This enables the source directories to be polled and fixes issues in WSL.